### PR TITLE
Fix a typo in a comment

### DIFF
--- a/.shells/colors
+++ b/.shells/colors
@@ -18,7 +18,7 @@ luma() {
     return 1
   fi
 
-  # Extract hex channels from backround color (RR/GG/BB)
+  # Extract hex channels from background color (RR/GG/BB)
   COLOR_HEX_RED=$(echo "$COLOR_HEX" | cut -d/ -f1)
   COLOR_HEX_GREEN=$(echo "$COLOR_HEX" | cut -d/ -f2)
   COLOR_HEX_BLUE=$(echo "$COLOR_HEX" | cut -d/ -f3)


### PR DESCRIPTION
I am about to steal the `luma` function from this file, and noticed a cosmetic typo in it.